### PR TITLE
Enable the SQL Query-Cache

### DIFF
--- a/.docksal/etc/mysql/my.cnf
+++ b/.docksal/etc/mysql/my.cnf
@@ -4,3 +4,6 @@
 #long_query_time=1
 #slow_query_log=1
 #slow_query_log_file=/dev/stdout
+
+# Enable sql query cache
+query_cache_type=1


### PR DESCRIPTION
This small config change enables the mysql query cache which was disabled by default.